### PR TITLE
Git deps should be marked as extra-deps.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -7,9 +7,11 @@ packages:
 - location:
     git: https://github.com/OlivierSohn/ansi-terminal.git
     commit: cb5ecbb9a89ceb24d06efa491e3ca44cf3f705f4
+  extra-dep: true
 - location:
     git: https://gitlab.com/OlivierSohn/Ease.git
     commit: 1d1398100135fa6571f37ff00a9607e886773a6f
+  extra-dep: true
 
 extra-deps:
 - monadlist-0.0.2


### PR DESCRIPTION
At least on more recent versions of `stack`, these need to be marked with `extra-dep: true`, otherwise `stack` will complain about not having `ease` in its snapshot, and will fail to see the changes on `ansi-terminal`.